### PR TITLE
Add support to operate on multiple db files

### DIFF
--- a/fintool/transac.py
+++ b/fintool/transac.py
@@ -110,6 +110,9 @@ class Transaction:
 
 
 class TransactionManager:
+
+    TRANSACTION_COLLECTION = 'records'
+
     @classmethod
     def create_transaction(cls, data):
         """Create a transaction from a dictionary instance.
@@ -156,7 +159,10 @@ class TransactionManager:
             'saving transaction in db'
         )
         fintool_db = DbFactory.get_db('csv')()
-        fintool_db.add_record(record=transaction.serialize())
+        fintool_db.add_record(
+            record=transaction.serialize(),
+            collection=cls.TRANSACTION_COLLECTION
+        )
 
     @classmethod
     def filter_transactions(cls, transactions, filters):
@@ -186,7 +192,9 @@ class TransactionManager:
             'getting transactions from db using filters = %s', filters
         )
         fintool_db = DbFactory.get_db('csv')()
-        transactions = cls.create_transaction_list(fintool_db.get_records())
+        transactions = cls.create_transaction_list(
+            fintool_db.get_records(cls.TRANSACTION_COLLECTION),
+        )
 
         if filters:
             transactions = cls.filter_transactions(transactions, filters)
@@ -207,7 +215,7 @@ class TransactionManager:
             'removing transaction %s', id_value
         )
         fintool_db = DbFactory.get_db('csv')()
-        fintool_db.remove_record(F_ID, id_value)
+        fintool_db.remove_record(F_ID, id_value, cls.TRANSACTION_COLLECTION)
 
     @classmethod
     def update_transaction(cls, data):
@@ -218,18 +226,11 @@ class TransactionManager:
                 'updating transaction %s with %s', data.id, data
             )
             fintool_db = DbFactory.get_db('csv')()
-            fintool_db.edit_record(F_ID, data.id, data.serialize())
+            fintool_db.edit_record(
+                F_ID,
+                data.id,
+                data.serialize(),
+                cls.TRANSACTION_COLLECTION
+            )
         else:
             raise InvalidTransactionError('invalid transaction object')
-
-
-class StatsHelper:
-    """Generate different types of stats based on a list of transactions
-    """
-
-    def __init__(self):
-        pass
-
-    @classmethod
-    def create_summary(cls):
-        pass

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -37,7 +37,7 @@ class TestCsvDb(unittest.TestCase):
         expected_record = '1,2,"[\'a\', \'b\', \'c\']"\n'
 
         file_db = fintool.db.CsvDb()
-        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']})
+        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']}, 'records')
 
         with self.RECORDS_FILE.open() as f:
             lines = f.readlines()
@@ -64,9 +64,9 @@ class TestCsvDb(unittest.TestCase):
         expected_content = 'a,b,c\n1,2,"[\'a\', \'b\', \'c\']"\n'
 
         file_db = fintool.db.CsvDb()
-        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']})
-        file_db.add_record({'a': 2, 'b': 3, 'c': ['a', 'b', 'c']})
-        file_db.remove_record(id_field='a', id_value='2')
+        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']}, 'records')
+        file_db.add_record({'a': 2, 'b': 3, 'c': ['a', 'b', 'c']}, 'records')
+        file_db.remove_record(id_field='a', id_value='2', collection='records')
 
         with self.RECORDS_FILE.open() as f:
             actual_content = f.read()
@@ -87,12 +87,12 @@ class TestCsvDb(unittest.TestCase):
 
         file_db = fintool.db.CsvDb()
 
-        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']})
-        file_db.add_record({'a': 2, 'b': 3, 'c': ['a', 'b', 'c']})
-        file_db.add_record({'a': 3, 'b': 4, 'c': ['a', 'b', 'c']})
-        file_db.add_record({'a': 4, 'b': 5, 'c': ['a', 'b', 'c']})
+        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']}, 'records')
+        file_db.add_record({'a': 2, 'b': 3, 'c': ['a', 'b', 'c']}, 'records')
+        file_db.add_record({'a': 3, 'b': 4, 'c': ['a', 'b', 'c']}, 'records')
+        file_db.add_record({'a': 4, 'b': 5, 'c': ['a', 'b', 'c']}, 'records')
 
-        actual_content = file_db.get_records()
+        actual_content = file_db.get_records('records')
 
         self.assertEqual(
             actual_content,
@@ -104,11 +104,12 @@ class TestCsvDb(unittest.TestCase):
         expected_content = 'a,b,c\n1,3,[\'a\']\n'
 
         file_db = fintool.db.CsvDb()
-        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']})
+        file_db.add_record({'a': 1, 'b': 2, 'c': ['a', 'b', 'c']}, 'records')
         file_db.edit_record(
             id_field='a',
             id_value='1',
-            new_record={'a': 1, 'b': 3, 'c': ['a']}
+            new_record={'a': 1, 'b': 3, 'c': ['a']},
+            collection='records'
         )
 
         with self.RECORDS_FILE.open() as f:


### PR DESCRIPTION
Update db module to support managing multiple db files. This is useful to persist data in isolated files by its context such as transactions, tags, and so on.

Signed-off-by: Isaias Ramirez <soote1.ir@gmail.com>