### PR TITLE
Improve transaction management

### DIFF
--- a/fintool/actions.py
+++ b/fintool/actions.py
@@ -90,9 +90,6 @@ class CreateFilters(Action):
         if data[self.TYPE]:
             filters[self.TYPE] = data[self.TYPE]
 
-        if data[self.DATE]:
-            filters[self.DATE] = data[self.DATE]
-
         if data[self.AMOUNT]:
             filters[self.AMOUNT] = data[self.AMOUNT]
 
@@ -109,6 +106,8 @@ class GetTransactions(Action):
     def __init__(self):
         self.TRANSACTIONS = 'transactions'
         self.FILTERS = 'filters'
+        self.FROM = 'from'
+        self.TO = 'to'
         self._logger = LoggingHelper.get_logger(self.__class__.__name__)
         super().__init__()
 
@@ -117,7 +116,11 @@ class GetTransactions(Action):
         """
         self._logger.debug('running action with: %s', data)
         transaction_manager = TransactionManager()
-        txs = transaction_manager.get_transactions(data.get(self.FILTERS))
+        txs = transaction_manager.get_transactions(
+            data[self.FROM],
+            data[self.TO],
+            filters=data[self.FILTERS]
+        )
         data[self.TRANSACTIONS] = txs
 
 
@@ -142,6 +145,8 @@ class RemoveTransaction(Action):
     """
     def __init__(self):
         self._logger = LoggingHelper.get_logger(self.__class__.__name__)
+        self.ID = 'id'
+        self.DATE = 'date'
         super().__init__()
 
     def exec(self, data):
@@ -150,7 +155,7 @@ class RemoveTransaction(Action):
         """
         self._logger.debug('running action with %s', data)
         transaction_manager = TransactionManager()
-        transaction_manager.remove_transaction(data)
+        transaction_manager.remove_transaction(data[self.DATE], data[self.ID])
 
 
 class UpdateTransaction(Action):
@@ -159,6 +164,8 @@ class UpdateTransaction(Action):
 
     def __init__(self):
         self._logger = LoggingHelper.get_logger(self.__class__.__name__)
+        self.OLD_DATE = 'olddate'
+        self.TRANSACTION = 'transaction'
         super().__init__()
 
     def exec(self, data):
@@ -168,7 +175,10 @@ class UpdateTransaction(Action):
         self._logger.debug('running action with %s', data)
         transaction_manager = TransactionManager()
         try:
-            transaction_manager.update_transaction(data['transaction'])
+            transaction_manager.update_transaction(
+                data[self.OLD_DATE],
+                data[self.TRANSACTION]
+            )
         except KeyError:
             raise ActionError('Missing input value: transaction')
 

--- a/fintool/cli.json
+++ b/fintool/cli.json
@@ -50,6 +50,13 @@
                 "help": "Transaction id",
                 "required": true
               }
+            },
+            {
+              "id": "--date",
+              "kwargs": {
+                "required": true,
+                "help": "Transaction date"
+              }
             }
           ]
         },
@@ -64,9 +71,17 @@
               }
             },
             {
-              "id": "--date",
+              "id": "--from",
               "kwargs": {
-                "help": "Date interval to filter transactions"
+                "required": true,
+                "help": "Start date to filter transactions"
+              }
+            },
+            {
+              "id": "--to",
+              "kwargs": {
+                "required": true,
+                "help": "End date to filter transactions"
               }
             },
             {
@@ -110,9 +125,17 @@
               }
             },
             {
-              "id": "--date",
+              "id": "--from",
               "kwargs": {
-                "help": "Date interval to filter transactions"
+                "required": true,
+                "help": "Start date to filter transactions"
+              }
+            },
+            {
+              "id": "--to",
+              "kwargs": {
+                "required": true,
+                "help": "End date to filter transactions"
               }
             },
             {
@@ -147,8 +170,16 @@
               }
             },
             {
+              "id": "--olddate",
+              "kwargs": {
+                "required": true,
+                "help": "Old transaction date"
+              }
+            },
+            {
               "id": "--date",
               "kwargs": {
+                "required": true,
                 "help": "New transaction date"
               }
             },

--- a/fintool/db.py
+++ b/fintool/db.py
@@ -94,12 +94,15 @@ class CsvDb(AbstractDb):
         Create file objects to manage records in collection file and return
         them in a tuple.
         """
-        return (
-            self._homedir_path.joinpath(self.RECORDS_FILE.format(collection)),
-            self._homedir_path.joinpath(
-                self.RECORDS_FILE_TMP.format(collection)
-            )
+        records_file = self._homedir_path.joinpath(
+            self.RECORDS_FILE.format(collection)
         )
+        # create dir if not exists
+        records_file.parent.mkdir(parents=True, exist_ok=True)
+        records_tmp_file = self._homedir_path.joinpath(
+            self.RECORDS_FILE_TMP.format(collection)
+        )
+        return (records_file, records_tmp_file)
 
     def add_record(self, record, collection):
         """Add a new record into csv file.

--- a/fintool/transac.py
+++ b/fintool/transac.py
@@ -6,7 +6,7 @@ This module provides classes to create and manage transactions.
 import uuid
 import datetime
 
-from fintool.db import CollectionNotFoundError, DbFactory
+from fintool.db import MissingCollectionError, DbFactory
 from fintool.logging import LoggingHelper
 
 
@@ -51,6 +51,7 @@ class Transaction:
     DATE = 'date'
     AMOUNT = 'amount'
     SUPPORTED_TYPES = {'income', 'outcome'}
+
     def __init__(self, t_type, t_tags, t_date, t_amount, t_id=None):
         """Do input validation on arguments and initialize fields.
 
@@ -266,7 +267,7 @@ class TransactionManager:
         for collection in collections:
             try:
                 records += self._db.get_records(collection)
-            except CollectionNotFoundError:
+            except MissingCollectionError:
                 # no problem, log message and continue with next collection
                 self._logger.debug('collection not found: %s', collection)
 
@@ -299,7 +300,7 @@ class TransactionManager:
         old_date_parts = old_date_str.split('-')
         new_date_parts = new_date_str.split('-')
         return old_date_parts[0] != new_date_parts[0] or \
-                old_date_parts[1] != new_date_parts[1]
+            old_date_parts[1] != new_date_parts[1]
 
     def update_transaction(self, old_date_str, data):
         """Update a transaction in db by using the provided id and data.

--- a/tests/fixtures/util.py
+++ b/tests/fixtures/util.py
@@ -1,0 +1,13 @@
+def remove_dir(dir_path):
+    """
+    Recursively remove directory.
+    """
+    try:
+        for f in dir_path.glob("*"):
+            if f.is_file():
+                f.unlink()
+            else:
+                remove_dir(f)
+        dir_path.rmdir()
+    except FileNotFoundError:
+        pass  # db doesn't exists

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,9 +32,9 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_parse_remove_cmd(self):
-        expected = {'cmd': 'remove', 'id': 'aasd'}
+        expected = {'cmd': 'remove', 'id': '1', 'date': '2020-01-01'}
 
-        cmd = ["remove", "--id", "aasd"]
+        cmd = ['remove', '--id', '1', '--date', '2020-01-01']
 
         cli = fintool.cli.CLI()
         actual = cli.parse_args(cmd)
@@ -45,17 +45,20 @@ class TestCLI(unittest.TestCase):
         expected = {
             'cmd': 'list',
             'type': 'income',
-            'date': 'sad-asdasd',
             'tags': 'a,b,c',
-            'amount': '12-32'
+            'amount': '12-32',
+            'from' : '2020-01-01',
+            'to': '2020-02-01'
         }
 
         cmd = [
             "list",
             "--type",
             "income",
-            "--date",
-            "sad-asdasd",
+            "--from",
+            "2020-01-01",
+            "--to",
+            "2020-02-01",
             "--amount",
             "12-32",
             "--tags",
@@ -73,7 +76,8 @@ class TestCLI(unittest.TestCase):
             'statstype': 'overall_summary',
             'draw': 'pie',
             'type': 'income',
-            'date': 'sad-asdasd',
+            'from': '2020-01-01',
+            'to': '2020-02-01',
             'tags': 'a,b,c',
             'amount': '12-32'
         }
@@ -86,8 +90,10 @@ class TestCLI(unittest.TestCase):
             "pie",
             "--type",
             "income",
-            "--date",
-            "sad-asdasd",
+            "--from",
+            "2020-01-01",
+            "--to",
+            "2020-02-01",
             "--amount",
             "12-32",
             "--tags",
@@ -104,7 +110,8 @@ class TestCLI(unittest.TestCase):
             'cmd': 'edit',
             'id': 'some-id',
             'type': 'some-type',
-            'date': 'some-date',
+            'olddate': '2020-01-01',
+            'date': '2020-02-01',
             'amount': '123.2',
             'tags': 'a,b,c'
         }
@@ -115,8 +122,10 @@ class TestCLI(unittest.TestCase):
             "some-id",
             "--type",
             "some-type",
+            "--olddate",
+            "2020-01-01",
             "--date",
-            "some-date",
+            "2020-02-01",
             "--amount",
             "123.2",
             "--tags",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,6 +3,8 @@ import unittest
 
 import fintool.db
 
+from tests.fixtures.util import remove_dir
+
 
 class TestCsvDb(unittest.TestCase):
     """Test CsvDb methods.
@@ -14,13 +16,7 @@ class TestCsvDb(unittest.TestCase):
         cls.RECORDS_FILE = cls.DB_DIR.joinpath("records.csv")
 
     def setUp(self):
-        try:
-            for f in self.DB_DIR.glob("*"):
-                f.unlink()
-
-            self.DB_DIR.rmdir()
-        except FileNotFoundError:
-            pass  # db doesn't exists
+        remove_dir(self.DB_DIR)
 
     def test_create_db(self):
 

--- a/tests/test_tagging.py
+++ b/tests/test_tagging.py
@@ -6,6 +6,7 @@ import pathlib
 
 from fintool.tagging import Tag, TagManager
 from fintool.db import CsvDb
+from tests.fixtures.util import remove_dir
 
 class TestTagging(unittest.TestCase):
     """
@@ -26,13 +27,7 @@ class TestTagging(unittest.TestCase):
         """
         Clean database on each test execution.
         """
-        try:
-            for f in self.DB_DIR.glob("*"):
-                f.unlink()
-
-            self.DB_DIR.rmdir()
-        except FileNotFoundError:
-            pass  # db doesn't exists
+        remove_dir(self.DB_DIR)
         self.tag_manager = TagManager()
 
     def add_tags(self, tags):

--- a/tests/test_transac.py
+++ b/tests/test_transac.py
@@ -2,6 +2,7 @@ import pathlib
 import unittest
 
 from fintool.transac import Transaction, TransactionManager
+from tests.fixtures.util import remove_dir
 
 
 class TestTransactions(unittest.TestCase):
@@ -13,14 +14,7 @@ class TestTransactions(unittest.TestCase):
         cls.RECORDS_FILE = cls.DB_DIR.joinpath("records.csv")
 
     def setUp(self):
-        try:
-            for f in self.DB_DIR.glob("*"):
-                f.unlink()
-
-            self.DB_DIR.rmdir()
-        except FileNotFoundError:
-            pass  # db doesn't exists
-
+        remove_dir(self.DB_DIR)
         self.transaction_manager = TransactionManager()
 
     def test_create_transaction(self):
@@ -60,6 +54,8 @@ class TestTransactions(unittest.TestCase):
         self.transaction_manager.save_transaction(actual)
 
     def test_get_transactions(self):
+        from_str = '2022-01-01'
+        to_str = '2023-01-01'
         expected = [
             Transaction.from_dict({
                 'id': '',
@@ -92,7 +88,7 @@ class TestTransactions(unittest.TestCase):
                 'tags': 'd|e|f'
             })
         )
-        actual = self.transaction_manager.get_transactions()
+        actual = self.transaction_manager.get_transactions(from_str, to_str)
 
         # compare everything but id
         for i in range(len(expected)):
@@ -121,6 +117,8 @@ class TestTransactions(unittest.TestCase):
             )
 
     def test_get_transactions_with_filters(self):
+        from_str = '2023-01-01'
+        to_str = '2023-01-01'
         expected = [
             Transaction.from_dict({
                 'id': '',
@@ -146,9 +144,11 @@ class TestTransactions(unittest.TestCase):
                 'tags': 'd|e|f'
             })
         )
-        actual = self.transaction_manager.get_transactions(filters={
-            'type': 'outcome'
-        })
+        actual = self.transaction_manager.get_transactions(
+            from_str,
+            to_str,
+            filters={'type': 'outcome'}
+        )
 
         # compare everything but id
         for i in range(len(expected)):
@@ -177,6 +177,8 @@ class TestTransactions(unittest.TestCase):
             )
 
     def test_get_transactions_by_tags(self):
+        from_str = '2022-01-01'
+        to_str = '2023-01-01'
         expected = [
             Transaction.from_dict({
                 'id': '',
@@ -202,9 +204,11 @@ class TestTransactions(unittest.TestCase):
                 'tags': 'd|e|f'
             })
         )
-        actual = self.transaction_manager.get_transactions(filters={
-            'tags': {'f'}
-        })
+        actual = self.transaction_manager.get_transactions(
+            from_str,
+            to_str,
+            filters={'tags': {'f'}}
+        )
 
         # compare everything but id
         for i in range(len(expected)):
@@ -233,6 +237,8 @@ class TestTransactions(unittest.TestCase):
             )
 
     def test_remove_transaction(self):
+        from_str = '2022-01-01'
+        to_str = '2022-01-01'
         expected = []
 
         self.transaction_manager.save_transaction(
@@ -243,13 +249,18 @@ class TestTransactions(unittest.TestCase):
                 'tags': 'a|b|c'
             })
         )
-        actual = self.transaction_manager.get_transactions()
-        self.transaction_manager.remove_transaction({'id': actual[0].id})
-        actual = self.transaction_manager.get_transactions()
+        actual = self.transaction_manager.get_transactions(from_str, to_str)
+        self.transaction_manager.remove_transaction(
+            from_str,
+            actual[0].id
+        )
+        actual = self.transaction_manager.get_transactions(from_str, to_str)
 
         self.assertEqual(actual, expected, "transaction list not equal")
 
     def test_edit_transaction(self):
+        from_str = '2022-01-01'
+        to_str = '2022-02-02'
         expected = [
             Transaction.from_dict({
                 'id': '9a80f28cbf5a4da0bcb1a4d6eed1796d',
@@ -271,6 +282,7 @@ class TestTransactions(unittest.TestCase):
         )
 
         self.transaction_manager.update_transaction(
+            to_str,
             Transaction.from_dict({
                 'id': '9a80f28cbf5a4da0bcb1a4d6eed1796d',
                 'type': 'income',
@@ -280,7 +292,7 @@ class TestTransactions(unittest.TestCase):
             })
         )
 
-        actual = self.transaction_manager.get_transactions()
+        actual = self.transaction_manager.get_transactions(from_str, to_str)
 
         self.assertEqual(
             actual[0].type,
@@ -305,3 +317,98 @@ class TestTransactions(unittest.TestCase):
             expected[0].tags,
             "transaction tags not equal"
         )
+
+    def test_calculate_namespace_from_date(self):
+        """
+        Make sure that TransactionManager knows how to create a collection
+        namespace from a date string.
+        """
+        expected = '2020/01'
+        input_data = '2020-01-01'
+        actual = self.transaction_manager.calculate_collection_from_date(
+            input_data
+        )
+        self.assertEqual(actual, expected, "namespace don't match")
+
+    def test_calculate_namespaces_from_date_range(self):
+        """
+        Make sure that TransactionManager knows how to create a list of
+        namespaces from a date range.
+        """
+        from_str = '2020-04-01'
+        to_str = '2022-04-01'
+        a = [
+            '2020/04',
+            '2020/05',
+            '2020/06',
+            '2020/07',
+            '2020/08',
+            '2020/09',
+            '2020/10',
+            '2020/11',
+            '2020/12',
+            '2021/01',
+            '2021/02',
+            '2021/03',
+            '2021/04',
+            '2021/05',
+            '2021/06',
+            '2021/07',
+            '2021/08',
+            '2021/09',
+            '2021/10',
+            '2021/11',
+            '2021/12',
+            '2022/01',
+            '2022/02',
+            '2022/03',
+            '2022/04',
+        ]
+        b = self.transaction_manager.calculate_collections_from_date_range(
+            from_str,
+            to_str
+        )
+
+        self.assertEqual(a, b, 'list of namespaces not equal')
+
+    def test_check_need_to_move_record_month(self):
+        """
+        Make sure that the TransactionManager can detect when to move a record.
+        """
+        old_date = '2020-01-02'
+        new_date = '2020-02-02'
+
+        actual = self.transaction_manager.check_need_to_move_record(
+            old_date,
+            new_date
+        )
+
+        self.assertTrue(actual, 'month is different, should be true')
+
+    def test_check_need_to_move_record_year(self):
+        """
+        Make sure that the TransactionManager can detect when to move a record.
+        """
+        old_date = '2020-02-02'
+        new_date = '2021-02-02'
+
+        actual = self.transaction_manager.check_need_to_move_record(
+            old_date,
+            new_date
+        )
+
+        self.assertTrue(actual, 'year is different, should be true')
+
+    def test_check_need_to_move_record_false(self):
+        """
+        Make sure that the TransactionManager can detect when to move a record.
+        """
+        old_date = '2020-02-02'
+        new_date = '2020-02-03'
+
+        actual = self.transaction_manager.check_need_to_move_record(
+            old_date,
+            new_date
+        )
+
+        self.assertFalse(actual, 'year and month are equal, should be false')


### PR DESCRIPTION
This PR provides two commits that change the way that transactions are handled in the db. Before this commit, all the transactions were persisted in a single file, which eventually would become a problem due to the amount of transactions that can be generated with the passage of time. Thus, the mechanism to manage the transactions has been changed. Now, the transactions are persisted in files according to the date of the transaction. That is, the year of the transaction defines the directory in which the file would be stored and the month defines the file in which the transaction will be persisted. An example path to a file would be /home/user/.fintool/2020/01.csv. These files are now called collections, since they represent a collection of transactions.