### PR TITLE
Rework cli to support multi-command mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,41 @@ A linux CLI app to help you manage your finances
 ## Usage
 ```
 python3 -m fintool.cli --help
-
-usage: cli.py [-h] {add,remove,list,stats,edit,add_tag,edit_tag,remove_tag,list_tags} ...
+usage: cli.py [-h] {txs,tags} ...
 
 positional arguments:
-  {add,remove,list,stats,edit,add_tag,edit_tag,remove_tag,list_tags}
+  {txs,tags}
+    txs       Manage transactions
+    tags      Manage tags
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+python3 -m fintool.cli txs --help
+usage: cli.py txs [-h] {add,remove,list,stats,edit} ...
+
+positional arguments:
+  {add,remove,list,stats,edit}
     add                 Add a transaction
     remove              Remove a transaction
     list                List transactions
     stats               show different types of stats about transactions
     edit                Edit a transaction
-    add_tag             Add a new tag to db
-    edit_tag            Update the values of a an existing tag
-    remove_tag          Remove a given tag from db
-    list_tags           List all tags in db
 
 optional arguments:
   -h, --help            show this help message and exit
+
+python3 -m fintool.cli tags --help
+usage: cli.py tags [-h] {add,edit,remove,list} ...
+
+positional arguments:
+  {add,edit,remove,list}
+    add                 Add a new tag to db
+    edit                Update the values of a an existing tag
+    remove              Remove a given tag from db
+    list                List all tags in db
+
+optional arguments:
+  -h, --help            show this help message and exit
+
 ```

--- a/fintool/cli.json
+++ b/fintool/cli.json
@@ -7,257 +7,279 @@
       "required": true,
       "subparsers_cfgs": [
         {
-          "name": "add",
-          "help": "Add a transaction",
-          "args": [
-            {
-              "id": "--type",
-              "kwargs": {
-                "required": true,
-                "help": "Transaction type"
-              }
-            },
-            {
-              "id": "--date",
-              "kwargs": {
-                "required": true,
-                "help": "Transaction date"
-              }
-            },
-            {
-              "id": "--amount",
-              "kwargs": {
-                "required": true,
-                "help": "Transaction amount"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "required": true,
-                "help": "A list of tags describing the transaction"
-              }
-            }
-          ]
-        },
-        {
-          "name": "remove",
-          "help": "Remove a transaction",
-          "args": [
-            {
-              "id": "--id",
-              "kwargs": {
-                "help": "Transaction id",
-                "required": true
-              }
-            },
-            {
-              "id": "--date",
-              "kwargs": {
-                "required": true,
-                "help": "Transaction date"
-              }
-            }
-          ]
-        },
-        {
-          "name": "list",
-          "help": "List transactions",
-          "args": [
-            {
-              "id": "--type",
-              "kwargs": {
-                "help": "Transaction type to filter transactions"
-              }
-            },
-            {
-              "id": "--from",
-              "kwargs": {
-                "required": true,
-                "help": "Start date to filter transactions"
-              }
-            },
-            {
-              "id": "--to",
-              "kwargs": {
-                "required": true,
-                "help": "End date to filter transactions"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "help": "Tags to filter transactions"
-              }
-            },
-            {
-              "id": "--amount",
-              "kwargs": {
-                "help": "Amount range to filter transactions"
-              }
-            }
-          ]
-        },
-        {
-          "name": "stats",
-          "help": "show different types of stats about transactions",
-          "args": [
-            {
-              "id": "--statstype",
-              "kwargs": {
-                "help": "Indicate what type of summary should be displayed",
-                "default": "overall_summary",
-                "choices": [
-                  "overall_summary"
+          "name": "txs",
+          "help": "Manage transactions",
+          "args": [],
+          "subparsers": {
+            "id": "action",
+            "required": true,
+            "subparsers_cfgs": [
+              {
+                "name": "add",
+                "help": "Add a transaction",
+                "args": [
+                  {
+                    "id": "--type",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Transaction type"
+                    }
+                  },
+                  {
+                    "id": "--date",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Transaction date"
+                    }
+                  },
+                  {
+                    "id": "--amount",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Transaction amount"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "required": true,
+                      "help": "A list of tags describing the transaction"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "remove",
+                "help": "Remove a transaction",
+                "args": [
+                  {
+                    "id": "--id",
+                    "kwargs": {
+                      "help": "Transaction id",
+                      "required": true
+                    }
+                  },
+                  {
+                    "id": "--date",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Transaction date"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "help": "List transactions",
+                "args": [
+                  {
+                    "id": "--type",
+                    "kwargs": {
+                      "help": "Transaction type to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--from",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Start date to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--to",
+                    "kwargs": {
+                      "required": true,
+                      "help": "End date to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "help": "Tags to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--amount",
+                    "kwargs": {
+                      "help": "Amount range to filter transactions"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "stats",
+                "help": "show different types of stats about transactions",
+                "args": [
+                  {
+                    "id": "--statstype",
+                    "kwargs": {
+                      "help": "Indicate what type of summary should be displayed",
+                      "default": "overall_summary",
+                      "choices": [
+                        "overall_summary"
+                      ]
+                    }
+                  },
+                  {
+                    "id": "--draw",
+                    "kwargs": {
+                      "help": "Show the stats in a chart"
+                    }
+                  },
+                  {
+                    "id": "--type",
+                    "kwargs": {
+                      "help": "Transaction type to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--from",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Start date to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--to",
+                    "kwargs": {
+                      "required": true,
+                      "help": "End date to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "help": "Tags to filter transactions"
+                    }
+                  },
+                  {
+                    "id": "--amount",
+                    "kwargs": {
+                      "help": "Amount range to filter transactions"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "edit",
+                "help": "Edit a transaction",
+                "args": [
+                  {
+                    "id": "--id",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Transaction id"
+                    }
+                  },
+                  {
+                    "id": "--type",
+                    "kwargs": {
+                      "help": "New transaction type"
+                    }
+                  },
+                  {
+                    "id": "--olddate",
+                    "kwargs": {
+                      "required": true,
+                      "help": "Old transaction date"
+                    }
+                  },
+                  {
+                    "id": "--date",
+                    "kwargs": {
+                      "required": true,
+                      "help": "New transaction date"
+                    }
+                  },
+                  {
+                    "id": "--amount",
+                    "kwargs": {
+                      "help": "New transaction amount"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "help": "New transaction tags"
+                    }
+                  }
                 ]
               }
-            },
-            {
-              "id": "--draw",
-              "kwargs": {
-                "help": "Show the stats in a chart"
-              }
-            },
-            {
-              "id": "--type",
-              "kwargs": {
-                "help": "Transaction type to filter transactions"
-              }
-            },
-            {
-              "id": "--from",
-              "kwargs": {
-                "required": true,
-                "help": "Start date to filter transactions"
-              }
-            },
-            {
-              "id": "--to",
-              "kwargs": {
-                "required": true,
-                "help": "End date to filter transactions"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "help": "Tags to filter transactions"
-              }
-            },
-            {
-              "id": "--amount",
-              "kwargs": {
-                "help": "Amount range to filter transactions"
-              }
-            }
-          ]
+            ]
+          }
         },
         {
-          "name": "edit",
-          "help": "Edit a transaction",
-          "args": [
-            {
-              "id": "--id",
-              "kwargs": {
-                "required": true,
-                "help": "Transaction id"
+          "name": "tags",
+          "help": "Manage tags",
+          "args": [],
+          "subparsers": {
+            "id": "action",
+            "required": true,
+            "subparsers_cfgs": [
+              {
+                "name": "add",
+                "help": "Add a new tag to db",
+                "args": [
+                  {
+                    "id": "--concept",
+                    "kwargs": {
+                      "help": "The concept that is related to the tags"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "help": "A | separated list of tags"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "edit",
+                "help": "Update the values of a an existing tag",
+                "args": [
+                  {
+                    "id": "--tagid",
+                    "kwargs": {
+                      "required": true,
+                      "help": "The tag identifier"
+                    }
+                  },
+                  {
+                    "id": "--concept",
+                    "kwargs": {
+                      "required": true,
+                      "help": "The concept that is related to the tags"
+                    }
+                  },
+                  {
+                    "id": "--tags",
+                    "kwargs": {
+                      "required": true,
+                      "help": "A | separated list of tags"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "remove",
+                "help": "Remove a given tag from db",
+                "args": [
+                  {
+                    "id": "--tagid",
+                    "kwargs": {
+                      "help": "The tag identifier"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "list",
+                "help": "List all tags in db",
+                "args": []
               }
-            },
-            {
-              "id": "--type",
-              "kwargs": {
-                "help": "New transaction type"
-              }
-            },
-            {
-              "id": "--olddate",
-              "kwargs": {
-                "required": true,
-                "help": "Old transaction date"
-              }
-            },
-            {
-              "id": "--date",
-              "kwargs": {
-                "required": true,
-                "help": "New transaction date"
-              }
-            },
-            {
-              "id": "--amount",
-              "kwargs": {
-                "help": "New transaction amount"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "help": "New transaction tags"
-              }
-            }
-          ]
-        },
-        {
-          "name": "add_tag",
-          "help": "Add a new tag to db",
-          "args": [
-            {
-              "id": "--concept",
-              "kwargs": {
-                "help": "The concept that is related to the tags"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "help": "A | separated list of tags"
-              }
-            }
-          ]
-        },
-        {
-          "name": "edit_tag",
-          "help": "Update the values of a an existing tag",
-          "args": [
-            {
-              "id": "--tagid",
-              "kwargs": {
-                "required": true,
-                "help": "The tag identifier"
-              }
-            },
-            {
-              "id": "--concept",
-              "kwargs": {
-                "required": true,
-                "help": "The concept that is related to the tags"
-              }
-            },
-            {
-              "id": "--tags",
-              "kwargs": {
-                "required": true,
-                "help": "A | separated list of tags"
-              }
-            }
-          ]
-        },
-        {
-          "name": "remove_tag",
-          "help": "Remove a given tag from db",
-          "args": [
-            {
-              "id": "--tagid",
-              "kwargs": {
-                "help": "The tag identifier"
-              }
-            }
-          ]
-        },
-        {
-          "name": "list_tags",
-          "help": "List all tags in db",
-          "args": []
+            ]
+          }
         }
       ]
     }

--- a/fintool/cli.py
+++ b/fintool/cli.py
@@ -36,15 +36,16 @@ KWARGS = "kwargs"
 CLI_CFG_FILE = "cli.json"
 ARGS_PARSER_CFG = "argsparser"
 CLI_CMD = "cmd"
-ADD_CMD = "add"
-REMOVE_CMD = "remove"
-LIST_CMD = "list"
-STATS_CMD = "stats"
-EDIT_CMD = "edit"
-ADD_TAG_CMD = 'add_tag'
-EDIT_TAG_CMD = 'edit_tag'
-REMOVE_TAG_CMD = 'remove_tag'
-LIST_TAGS_CMD = 'list_tags'
+CMD_ACTION = 'action'
+ADD_TX_CMD = "txs.add"
+REMOVE_TX_CMD = "txs.remove"
+LIST_TX_CMD = "txs.list"
+STATS_TX_CMD = "txs.stats"
+EDIT_TX_CMD = "txs.edit"
+ADD_TAG_CMD = 'tags.add'
+EDIT_TAG_CMD = 'tags.edit'
+REMOVE_TAG_CMD = 'tags.remove'
+LIST_TAGS_CMD = 'tags.list'
 
 
 class ArgsParser:
@@ -128,11 +129,11 @@ class CommandProcessor:
 
 
 SUPPORTED_CMDS = {
-    ADD_CMD: [CreateTransaction, SaveTransaction],
-    REMOVE_CMD: [RemoveTransaction],
-    LIST_CMD: [CreateFilters, GetTransactions, PrintTransactions],
-    STATS_CMD: [CreateFilters, GetTransactions, CreateStats, ShowStats],
-    EDIT_CMD: [CreateTransaction, UpdateTransaction],
+    ADD_TX_CMD: [CreateTransaction, SaveTransaction],
+    REMOVE_TX_CMD: [RemoveTransaction],
+    LIST_TX_CMD: [CreateFilters, GetTransactions, PrintTransactions],
+    STATS_TX_CMD: [CreateFilters, GetTransactions, CreateStats, ShowStats],
+    EDIT_TX_CMD: [CreateTransaction, UpdateTransaction],
     ADD_TAG_CMD: [CreateTag, AddTag],
     EDIT_TAG_CMD: [CreateTag, EditTag],
     REMOVE_TAG_CMD: [RemoveTag],
@@ -182,10 +183,12 @@ class CLI:
         self._logger.debug('creating command from args: %s', args)
         try:
             cmd_id = args[CLI_CMD]
+            cmd_action = args[CMD_ACTION]
+            cmd_namespace = f'{cmd_id}.{cmd_action}'
             # cmd data consists of all key-values in args except cmd id
-            cmd_data = {k: args[k] for k in args.keys() - {CLI_CMD}}
-            cmd_actions = SUPPORTED_CMDS[cmd_id]
-            return Command(cmd_id, cmd_actions, cmd_data)
+            cmd_data = {k: args[k] for k in args.keys() - {CLI_CMD, CMD_ACTION}}
+            cmd_actions = SUPPORTED_CMDS[cmd_namespace]
+            return Command(cmd_namespace, cmd_actions, cmd_data)
         except KeyError as key_error:
             raise UnsupportedCmdError(f"Unsupported command: {key_error}")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,9 +5,10 @@ import fintool.actions
 
 class TestCLI(unittest.TestCase):
 
-    def test_parse_add_cmd(self):
+    def test_parse_add_tx_cmd(self):
         expected = {
-            'cmd': 'add',
+            'cmd': 'txs',
+            'action': 'add',
             'type': 'some',
             'date': 'other',
             'amount': '12.12',
@@ -15,6 +16,7 @@ class TestCLI(unittest.TestCase):
         }
 
         cmd = [
+            "txs",
             "add",
             "--type",
             "some",
@@ -32,9 +34,14 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_parse_remove_cmd(self):
-        expected = {'cmd': 'remove', 'id': '1', 'date': '2020-01-01'}
+        expected = {
+            'cmd': 'txs',
+            'action': 'remove',
+            'id': '1',
+            'date': '2020-01-01'
+        }
 
-        cmd = ['remove', '--id', '1', '--date', '2020-01-01']
+        cmd = ['txs', 'remove', '--id', '1', '--date', '2020-01-01']
 
         cli = fintool.cli.CLI()
         actual = cli.parse_args(cmd)
@@ -43,15 +50,17 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_list_cmd(self):
         expected = {
-            'cmd': 'list',
+            'cmd': 'txs',
+            'action': 'list',
             'type': 'income',
             'tags': 'a,b,c',
             'amount': '12-32',
-            'from' : '2020-01-01',
+            'from': '2020-01-01',
             'to': '2020-02-01'
         }
 
         cmd = [
+            "txs",
             "list",
             "--type",
             "income",
@@ -72,7 +81,8 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_stats_cmd(self):
         expected = {
-            'cmd': 'stats',
+            'cmd': 'txs',
+            'action': 'stats',
             'statstype': 'overall_summary',
             'draw': 'pie',
             'type': 'income',
@@ -83,6 +93,7 @@ class TestCLI(unittest.TestCase):
         }
 
         cmd = [
+            "txs",
             "stats",
             "--statstype",
             "overall_summary",
@@ -107,7 +118,8 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_edit_cmd(self):
         expected = {
-            'cmd': 'edit',
+            'cmd': 'txs',
+            'action': 'edit',
             'id': 'some-id',
             'type': 'some-type',
             'olddate': '2020-01-01',
@@ -117,6 +129,7 @@ class TestCLI(unittest.TestCase):
         }
 
         cmd = [
+            "txs",
             "edit",
             "--id",
             "some-id",
@@ -142,8 +155,8 @@ class TestCLI(unittest.TestCase):
             fintool.actions.CreateTransaction,
             fintool.actions.SaveTransaction
         ]
-        expected_cmd = fintool.cli.Command("add", expected_actions, None)
-        args = {'cmd': 'add', 'other': None}
+        expected_cmd = fintool.cli.Command("txs.add", expected_actions, None)
+        args = {'cmd': 'txs', 'action': 'add', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -151,8 +164,12 @@ class TestCLI(unittest.TestCase):
 
     def test_create_remove_cmd(self):
         expected_actions = [fintool.actions.RemoveTransaction]
-        expected_cmd = fintool.cli.Command("remove", expected_actions, None)
-        args = {'cmd': 'remove', 'other': None}
+        expected_cmd = fintool.cli.Command(
+            "txs.remove",
+            expected_actions,
+            None
+        )
+        args = {'cmd': 'txs', 'action': 'remove', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -165,8 +182,8 @@ class TestCLI(unittest.TestCase):
             fintool.actions.PrintTransactions
         ]
 
-        expected_cmd = fintool.cli.Command("list", expected_actions, None)
-        args = {'cmd': 'list', 'other': None}
+        expected_cmd = fintool.cli.Command("txs.list", expected_actions, None)
+        args = {'cmd': 'txs', 'action': 'list', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -181,9 +198,9 @@ class TestCLI(unittest.TestCase):
             fintool.actions.CreateTransaction,
             fintool.actions.UpdateTransaction
         ]
-        expected_cmd = fintool.cli.Command("edit", expected_actions, None)
+        expected_cmd = fintool.cli.Command("txs.edit", expected_actions, None)
 
-        args = {'cmd': 'edit', 'other': None}
+        args = {'cmd': 'txs', 'action': 'edit', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -202,9 +219,9 @@ class TestCLI(unittest.TestCase):
             fintool.actions.CreateTag,
             fintool.actions.AddTag
         ]
-        expected_cmd = fintool.cli.Command("add_tag", expected_actions, None)
+        expected_cmd = fintool.cli.Command("tags.add", expected_actions, None)
 
-        args = {'cmd': 'add_tag', 'other': None}
+        args = {'cmd': 'tags', 'action': 'add', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -215,9 +232,9 @@ class TestCLI(unittest.TestCase):
             fintool.actions.CreateTag,
             fintool.actions.EditTag
         ]
-        expected_cmd = fintool.cli.Command("edit_tag", expected_actions, None)
+        expected_cmd = fintool.cli.Command("tags.edit", expected_actions, None)
 
-        args = {'cmd': 'edit_tag', 'other': None}
+        args = {'cmd': 'tags', 'action': 'edit', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -228,12 +245,12 @@ class TestCLI(unittest.TestCase):
             fintool.actions.RemoveTag
         ]
         expected_cmd = fintool.cli.Command(
-            "remove_tag",
+            "tags.remove",
             expected_actions,
             None
         )
 
-        args = {'cmd': 'remove_tag', 'other': None}
+        args = {'cmd': 'tags', 'action': 'remove', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -245,12 +262,12 @@ class TestCLI(unittest.TestCase):
             fintool.actions.PrintTags
         ]
         expected_cmd = fintool.cli.Command(
-            "list_tags",
+            "tags.list",
             expected_actions,
             None
         )
 
-        args = {'cmd': 'list_tags', 'other': None}
+        args = {'cmd': 'tags', 'action': 'list', 'other': None}
         actual = fintool.cli.CLI().create_cmd(args)
 
         self.assertEqual(actual.cmd, expected_cmd.cmd)
@@ -258,13 +275,15 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_add_tag_cmd(self):
         expected = {
-            'cmd': 'add_tag',
+            'cmd': 'tags',
+            'action': 'add',
             'concept': 'some_concept',
             'tags': 'a|b|c'
         }
 
         cmd = [
-            "add_tag",
+            "tags",
+            "add",
             "--concept",
             "some_concept",
             "--tags",
@@ -278,14 +297,16 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_edit_tag_cmd(self):
         expected = {
-            'cmd': 'edit_tag',
+            'cmd': 'tags',
+            'action': 'edit',
             'concept': 'some_concept',
             'tags': 'a|b|c',
             'tagid': 'some_id'
         }
 
         cmd = [
-            "edit_tag",
+            "tags",
+            "edit",
             "--concept",
             "some_concept",
             "--tags",
@@ -301,12 +322,14 @@ class TestCLI(unittest.TestCase):
 
     def test_parse_remove_tag_cmd(self):
         expected = {
-            'cmd': 'remove_tag',
+            'cmd': 'tags',
+            'action': 'remove',
             'tagid': 'some_id'
         }
 
         cmd = [
-            "remove_tag",
+            "tags",
+            "remove",
             "--tagid",
             "some_id"
         ]
@@ -317,13 +340,9 @@ class TestCLI(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def test_parse_list_tags_cmd(self):
-        expected = {
-            'cmd': 'list_tags',
-        }
+        expected = {'cmd': 'tags', 'action': 'list'}
 
-        cmd = [
-            "list_tags",
-        ]
+        cmd = ["tags", "list"]
 
         cli = fintool.cli.CLI()
         actual = cli.parse_args(cmd)


### PR DESCRIPTION
This PR provides the tool with multi-command support in the cli module. Since the argument parser helper class already supports loading sub parsers, the changes were required only in cli's config file (`cli.json`) and `CLI` class. Now, the way in which we identify the corresponding workflow is by command namespace (`cmd.action`). 

Signed-off-by: Isaias Ramirez <soote1.ir@gmail.com>